### PR TITLE
Fix a typo in type name

### DIFF
--- a/include/boost/detail/winapi/crypt.hpp
+++ b/include/boost/detail/winapi/crypt.hpp
@@ -53,8 +53,8 @@ extern "C" {
     __declspec(dllimport) BOOL_ __stdcall
         CryptAcquireContextA(
             HCRYPTPROV_ *phProv,
-            LPCTSTR_ pszContainer,
-            LPCTSTR_ pszProvider,
+            LPCSTR_ pszContainer,
+            LPCSTR_ pszProvider,
             DWORD_ dwProvType,
             DWORD_ dwFlags
     );


### PR DESCRIPTION
(this fix is related to https://github.com/boostorg/uuid/pull/2)
