### PR TITLE
ADD Create*Ex SUPPORT FOR SYNCHRONIZATION PRIMITIVES

### DIFF
--- a/include/boost/detail/winapi/event.hpp
+++ b/include/boost/detail/winapi/event.hpp
@@ -19,12 +19,23 @@
 #if !defined( BOOST_USE_WINDOWS_H )
 extern "C" {
 #if !defined( BOOST_NO_ANSI_APIS )
+#if !defined( BOOST_PLAT_WINDOWS_RUNTIME_AVALIABLE )
 BOOST_SYMBOL_IMPORT boost::detail::winapi::HANDLE_ WINAPI
 CreateEventA(
     ::_SECURITY_ATTRIBUTES* lpEventAttributes,
     boost::detail::winapi::BOOL_ bManualReset,
     boost::detail::winapi::BOOL_ bInitialState,
     boost::detail::winapi::LPCSTR_ lpName);
+#endif
+
+#if BOOST_USE_WINAPI_VERSION >= BOOST_WINAPI_VERSION_WIN6
+BOOST_SYMBOL_IMPORT boost::detail::winapi::HANDLE_ WINAPI
+CreateEventExA(
+    ::_SECURITY_ATTRIBUTES *lpEventAttributes,
+    boost::detail::winapi::LPCSTR_ lpName,
+    boost::detail::winapi::DWORD_ dwFlags,
+    boost::detail::winapi::DWORD_ dwDesiredAccess);
+#endif
 
 BOOST_SYMBOL_IMPORT boost::detail::winapi::HANDLE_ WINAPI
 OpenEventA(
@@ -39,6 +50,15 @@ CreateEventW(
     boost::detail::winapi::BOOL_ bManualReset,
     boost::detail::winapi::BOOL_ bInitialState,
     boost::detail::winapi::LPCWSTR_ lpName);
+
+#if BOOST_USE_WINAPI_VERSION >= BOOST_WINAPI_VERSION_WIN6
+BOOST_SYMBOL_IMPORT boost::detail::winapi::HANDLE_ WINAPI
+CreateEventExW(
+    ::_SECURITY_ATTRIBUTES *lpEventAttributes,
+    boost::detail::winapi::LPCWSTR_ lpName,
+    boost::detail::winapi::DWORD_ dwFlags,
+    boost::detail::winapi::DWORD_ dwDesiredAccess);
+#endif
 
 BOOST_SYMBOL_IMPORT boost::detail::winapi::HANDLE_ WINAPI
 OpenEventW(
@@ -68,22 +88,76 @@ using ::OpenEventW;
 using ::SetEvent;
 using ::ResetEvent;
 
+#if defined( BOOST_USE_WINDOWS_H )
+
+const DWORD_ CREATE_EVENT_INITIAL_SET_ = CREATE_EVENT_INITIAL_SET;
+const DWORD_ CREATE_EVENT_MANUAL_RESET_ = CREATE_EVENT_MANUAL_RESET;
+const DWORD_ EVENT_ALL_ACCESS_ = EVENT_ALL_ACCESS;
+
+#else // defined( BOOST_USE_WINDOWS_H )
+    
+const DWORD_ CREATE_EVENT_INITIAL_SET_ = 0x00000002;
+const DWORD_ CREATE_EVENT_MANUAL_RESET_ = 0x00000001;
+const DWORD_ EVENT_ALL_ACCESS_ = 0x1F0003;
+
+#endif // defined( BOOST_USE_WINDOWS_H )
+
+const DWORD_ create_event_initial_set = CREATE_EVENT_INITIAL_SET_;
+const DWORD_ create_event_manual_reset = CREATE_EVENT_MANUAL_RESET_;
+const DWORD_ event_all_access = EVENT_ALL_ACCESS_;
+
+
 #if !defined( BOOST_NO_ANSI_APIS )
 BOOST_FORCEINLINE HANDLE_ CreateEventA(SECURITY_ATTRIBUTES_* lpEventAttributes, BOOL_ bManualReset, BOOL_ bInitialState, LPCSTR_ lpName)
 {
+#if !defined( BOOST_PLAT_WINDOWS_RUNTIME_AVALIABLE )
     return ::CreateEventA(reinterpret_cast< ::_SECURITY_ATTRIBUTES* >(lpEventAttributes), bManualReset, bInitialState, lpName);
+#else
+    DWORD_ flags = (bManualReset ? create_event_manual_reset : 0)
+                 | (bInitialState ? create_event_initial_set : 0)
+                 ;
+    return ::CreateEventExA(reinterpret_cast< ::_SECURITY_ATTRIBUTES* >(lpEventAttributes), lpName, flags, event_all_access); 
+#endif
 }
+
+#if BOOST_USE_WINAPI_VERSION >= BOOST_WINAPI_VERSION_WIN6
+BOOST_FORCEINLINE HANDLE_ CreateEventExA(SECURITY_ATTRIBUTES_* lpEventAttributes, LPCSTR_ lpName, DWORD_ dwFlags, DWORD_ dwDesiredAccess)
+{
+    return ::CreateEventExA(reinterpret_cast< ::_SECURITY_ATTRIBUTES* >(lpEventAttributes), lpName, dwFlags, dwDesiredAccess);
+}
+#endif
 #endif
 
 BOOST_FORCEINLINE HANDLE_ CreateEventW(SECURITY_ATTRIBUTES_* lpEventAttributes, BOOL_ bManualReset, BOOL_ bInitialState, LPCWSTR_ lpName)
 {
+#if !defined( BOOST_PLAT_WINDOWS_RUNTIME_AVALIABLE )
     return ::CreateEventW(reinterpret_cast< ::_SECURITY_ATTRIBUTES* >(lpEventAttributes), bManualReset, bInitialState, lpName);
+#else
+    DWORD_ flags = (bManualReset ? create_event_manual_reset : 0)
+                 | (bInitialState ? create_event_initial_set : 0)
+                 ;
+    return ::CreateEventExW(reinterpret_cast< ::_SECURITY_ATTRIBUTES* >(lpEventAttributes), lpName, flags, event_all_access); 
+#endif
 }
+
+#if BOOST_USE_WINAPI_VERSION >= BOOST_WINAPI_VERSION_WIN6
+BOOST_FORCEINLINE HANDLE_ CreateEventExW(SECURITY_ATTRIBUTES_* lpEventAttributes, LPCWSTR_ lpName, DWORD_ dwFlags, DWORD_ dwDesiredAccess)
+{
+    return ::CreateEventExW(reinterpret_cast< ::_SECURITY_ATTRIBUTES* >(lpEventAttributes), lpName, dwFlags, dwDesiredAccess);
+}
+#endif
 
 #if !defined( BOOST_NO_ANSI_APIS )
 BOOST_FORCEINLINE HANDLE_ create_event(SECURITY_ATTRIBUTES_* lpEventAttributes, BOOL_ bManualReset, BOOL_ bInitialState, LPCSTR_ lpName)
 {
+#if !defined( BOOST_PLAT_WINDOWS_RUNTIME_AVALIABLE )
     return ::CreateEventA(reinterpret_cast< ::_SECURITY_ATTRIBUTES* >(lpEventAttributes), bManualReset, bInitialState, lpName);
+#else
+    DWORD_ flags = (bManualReset ? create_event_manual_reset : 0)
+                 | (bInitialState ? create_event_initial_set : 0)
+                 ;
+    return ::CreateEventExA(reinterpret_cast< ::_SECURITY_ATTRIBUTES* >(lpEventAttributes), lpName, flags, event_all_access); 
+#endif
 }
 
 BOOST_FORCEINLINE HANDLE_ open_event(DWORD_ dwDesiredAccess, BOOL_ bInheritHandle, LPCSTR_ lpName)
@@ -94,7 +168,14 @@ BOOST_FORCEINLINE HANDLE_ open_event(DWORD_ dwDesiredAccess, BOOL_ bInheritHandl
 
 BOOST_FORCEINLINE HANDLE_ create_event(SECURITY_ATTRIBUTES_* lpEventAttributes, BOOL_ bManualReset, BOOL_ bInitialState, LPCWSTR_ lpName)
 {
+#if !defined( BOOST_PLAT_WINDOWS_RUNTIME_AVALIABLE )
     return ::CreateEventW(reinterpret_cast< ::_SECURITY_ATTRIBUTES* >(lpEventAttributes), bManualReset, bInitialState, lpName);
+#else
+    DWORD_ flags = (bManualReset ? create_event_manual_reset : 0)
+                 | (bInitialState ? create_event_initial_set : 0)
+                 ;
+    return ::CreateEventExW(reinterpret_cast< ::_SECURITY_ATTRIBUTES* >(lpEventAttributes), lpName, flags, event_all_access); 
+#endif
 }
 
 BOOST_FORCEINLINE HANDLE_ open_event(DWORD_ dwDesiredAccess, BOOL_ bInheritHandle, LPCWSTR_ lpName)
@@ -104,10 +185,13 @@ BOOST_FORCEINLINE HANDLE_ open_event(DWORD_ dwDesiredAccess, BOOL_ bInheritHandl
 
 BOOST_FORCEINLINE HANDLE_ create_anonymous_event(SECURITY_ATTRIBUTES_* lpEventAttributes, BOOL_ bManualReset, BOOL_ bInitialState)
 {
-#ifdef BOOST_NO_ANSI_APIS
+#if !defined( BOOST_PLAT_WINDOWS_RUNTIME_AVALIABLE )
     return ::CreateEventW(reinterpret_cast< ::_SECURITY_ATTRIBUTES* >(lpEventAttributes), bManualReset, bInitialState, 0);
 #else
-    return ::CreateEventA(reinterpret_cast< ::_SECURITY_ATTRIBUTES* >(lpEventAttributes), bManualReset, bInitialState, 0);
+    DWORD_ flags = (bManualReset ? create_event_manual_reset : 0)
+                 | (bInitialState ? create_event_initial_set : 0)
+                 ;
+    return ::CreateEventExW(reinterpret_cast< ::_SECURITY_ATTRIBUTES* >(lpEventAttributes), 0, flags, event_all_access); 
 #endif
 }
 

--- a/include/boost/detail/winapi/mutex.hpp
+++ b/include/boost/detail/winapi/mutex.hpp
@@ -19,11 +19,22 @@
 #if !defined( BOOST_USE_WINDOWS_H )
 extern "C" {
 #if !defined( BOOST_NO_ANSI_APIS )
+#if !defined( BOOST_PLAT_WINDOWS_RUNTIME_AVALIABLE )
 BOOST_SYMBOL_IMPORT boost::detail::winapi::HANDLE_ WINAPI
 CreateMutexA(
     ::_SECURITY_ATTRIBUTES* lpMutexAttributes,
     boost::detail::winapi::BOOL_ bInitialOwner,
     boost::detail::winapi::LPCSTR_ lpName);
+#endif
+
+#if BOOST_USE_WINAPI_VERSION >= BOOST_WINAPI_VERSION_WIN6
+BOOST_SYMBOL_IMPORT boost::detail::winapi::HANDLE_ WINAPI
+CreateMutexExA(
+    ::_SECURITY_ATTRIBUTES* lpMutexAttributes,
+    boost::detail::winapi::LPCSTR_ lpName,
+    boost::detail::winapi::DWORD_ dwFlags,
+    boost::detail::winapi::DWORD_ dwDesiredAccess);
+#endif
 
 BOOST_SYMBOL_IMPORT boost::detail::winapi::HANDLE_ WINAPI
 OpenMutexA(
@@ -32,11 +43,22 @@ OpenMutexA(
     boost::detail::winapi::LPCSTR_ lpName);
 #endif
 
+#if !defined( BOOST_PLAT_WINDOWS_RUNTIME_AVALIABLE )
 BOOST_SYMBOL_IMPORT boost::detail::winapi::HANDLE_ WINAPI
 CreateMutexW(
     ::_SECURITY_ATTRIBUTES* lpMutexAttributes,
     boost::detail::winapi::BOOL_ bInitialOwner,
     boost::detail::winapi::LPCWSTR_ lpName);
+#endif
+
+#if BOOST_USE_WINAPI_VERSION >= BOOST_WINAPI_VERSION_WIN6
+BOOST_SYMBOL_IMPORT boost::detail::winapi::HANDLE_ WINAPI
+CreateMutexExW(
+    ::_SECURITY_ATTRIBUTES* lpMutexAttributes,
+    boost::detail::winapi::LPCWSTR_ lpName,
+    boost::detail::winapi::DWORD_ dwFlags,
+    boost::detail::winapi::DWORD_ dwDesiredAccess);
+#endif
 
 BOOST_SYMBOL_IMPORT boost::detail::winapi::HANDLE_ WINAPI
 OpenMutexW(
@@ -59,28 +81,81 @@ using ::OpenMutexA;
 using ::OpenMutexW;
 using ::ReleaseMutex;
 
+#if defined( BOOST_USE_WINDOWS_H )
+
+const DWORD_ MUTEX_ALL_ACCESS_ = MUTEX_ALL_ACCESS;
+const DWORD_ CREATE_MUTEX_INITIAL_OWNER_ = CREATE_MUTEX_INITIAL_OWNER;
+
+#else
+
+const DWORD_ MUTEX_ALL_ACCESS_ = 0x00000001;
+const DWORD_ CREATE_MUTEX_INITIAL_OWNER_ = 0x1F0001;
+
+#endif
+
+const DWORD_ mutex_all_access = MUTEX_ALL_ACCESS_;
+const DWORD_ create_mutex_initial_owner = CREATE_MUTEX_INITIAL_OWNER_;
+
+
 #if !defined( BOOST_NO_ANSI_APIS )
 BOOST_FORCEINLINE HANDLE_ CreateMutexA(
     SECURITY_ATTRIBUTES_* lpMutexAttributes,
     BOOL_ bInitialOwner,
     LPCSTR_ lpName)
 {
+#if !defined( BOOST_PLAT_WINDOWS_RUNTIME_AVALIABLE )
     return ::CreateMutexA(reinterpret_cast< ::_SECURITY_ATTRIBUTES* >(lpMutexAttributes), bInitialOwner, lpName);
+#else
+    DWORD_ flags = bInitialOwner ? create_mutex_initial_owner : 0;
+    return ::CreateMutexExA(reinterpret_cast< ::_SECURITY_ATTRIBUTES* >(lpMutexAttributes), lpName, flags, mutex_all_access);
+#endif
 }
+
+#if BOOST_USE_WINAPI_VERSION >= BOOST_WINAPI_VERSION_WIN6
+BOOST_FORCEINLINE HANDLE_ CreateMutexExA(
+    SECURITY_ATTRIBUTES_* lpMutexAttributes,
+    LPCSTR_ lpName,
+    DWORD_ dwFlags,
+    DWORD_ dwDesiredAccess)
+{
+    return ::CreateMutexExA(reinterpret_cast< ::_SECURITY_ATTRIBUTES* >(lpMutexAttributes), lpName, dwFlags, dwDesiredAccess);
+}
+#endif
 #endif
 
 BOOST_FORCEINLINE HANDLE_ CreateMutexW(
-    ::_SECURITY_ATTRIBUTES* lpMutexAttributes,
+    ::SECURITY_ATTRIBUTES_* lpMutexAttributes,
     BOOL_ bInitialOwner,
     LPCWSTR_ lpName)
 {
+#if !defined( BOOST_PLAT_WINDOWS_RUNTIME_AVALIABLE )
     return ::CreateMutexW(reinterpret_cast< ::_SECURITY_ATTRIBUTES* >(lpMutexAttributes), bInitialOwner, lpName);
+#else
+    DWORD_ flags = bInitialOwner ? create_mutex_initial_owner : 0;
+    return ::CreateMutexExW(reinterpret_cast< ::_SECURITY_ATTRIBUTES* >(lpMutexAttributes), lpName, flags, mutex_all_access);
+#endif
 }
+
+#if BOOST_USE_WINAPI_VERSION >= BOOST_WINAPI_VERSION_WIN6
+BOOST_FORCEINLINE HANDLE_ CreateMutexExW(
+    SECURITY_ATTRIBUTES_* lpMutexAttributes,
+    LPCWSTR_ lpName,
+    DWORD_ dwFlags,
+    DWORD_ dwDesiredAccess)
+{
+    return ::CreateMutexExW(reinterpret_cast< ::_SECURITY_ATTRIBUTES* >(lpMutexAttributes), lpName, dwFlags, dwDesiredAccess);
+}
+#endif
 
 #if !defined( BOOST_NO_ANSI_APIS )
 BOOST_FORCEINLINE HANDLE_ create_mutex(SECURITY_ATTRIBUTES_* lpAttributes, BOOL_ bInitialOwner, LPCSTR_ lpName)
 {
-    return ::CreateMutexA(reinterpret_cast< ::_SECURITY_ATTRIBUTES* >(lpAttributes), bInitialOwner, lpName);
+#if !defined( BOOST_PLAT_WINDOWS_RUNTIME_AVALIABLE )
+    return ::CreateMutexA(reinterpret_cast< ::_SECURITY_ATTRIBUTES* >(lpMutexAttributes), bInitialOwner, lpName);
+#else
+    DWORD_ flags = bInitialOwner ? create_mutex_initial_owner : 0;
+    return ::CreateMutexExA(reinterpret_cast< ::_SECURITY_ATTRIBUTES* >(lpMutexAttributes), lpName, flags, mutex_all_access);
+#endif
 }
 
 BOOST_FORCEINLINE HANDLE_ open_mutex(DWORD_ dwDesiredAccess, BOOL_ bInheritHandle, LPCSTR_ lpName)
@@ -91,7 +166,12 @@ BOOST_FORCEINLINE HANDLE_ open_mutex(DWORD_ dwDesiredAccess, BOOL_ bInheritHandl
 
 BOOST_FORCEINLINE HANDLE_ create_mutex(SECURITY_ATTRIBUTES_* lpAttributes, BOOL_ bInitialOwner, LPCWSTR_ lpName)
 {
-    return ::CreateMutexW(reinterpret_cast< ::_SECURITY_ATTRIBUTES* >(lpAttributes), bInitialOwner, lpName);
+#if !defined( BOOST_PLAT_WINDOWS_RUNTIME_AVALIABLE )
+    return ::CreateMutexW(reinterpret_cast< ::_SECURITY_ATTRIBUTES* >(lpMutexAttributes), bInitialOwner, lpName);
+#else
+    DWORD_ flags = bInitialOwner ? create_mutex_initial_owner : 0;
+    return ::CreateMutexExW(reinterpret_cast< ::_SECURITY_ATTRIBUTES* >(lpMutexAttributes), lpName, flags, mutex_all_access);
+#endif
 }
 
 BOOST_FORCEINLINE HANDLE_ open_mutex(DWORD_ dwDesiredAccess, BOOL_ bInheritHandle, LPCWSTR_ lpName)
@@ -101,10 +181,11 @@ BOOST_FORCEINLINE HANDLE_ open_mutex(DWORD_ dwDesiredAccess, BOOL_ bInheritHandl
 
 BOOST_FORCEINLINE HANDLE_ create_anonymous_mutex(SECURITY_ATTRIBUTES_* lpAttributes, BOOL_ bInitialOwner)
 {
-#ifdef BOOST_NO_ANSI_APIS
+#if !defined( BOOST_PLAT_WINDOWS_RUNTIME_AVALIABLE )
     return ::CreateMutexW(reinterpret_cast< ::_SECURITY_ATTRIBUTES* >(lpAttributes), bInitialOwner, 0);
 #else
-    return ::CreateMutexA(reinterpret_cast< ::_SECURITY_ATTRIBUTES* >(lpAttributes), bInitialOwner, 0);
+    DWORD_ flags = bInitialOwner ? create_mutex_initial_owner : 0;
+    return ::CreateMutexExW(reinterpret_cast< ::_SECURITY_ATTRIBUTES* >(lpMutexAttributes), 0, flags, mutex_all_access);
 #endif
 }
 

--- a/include/boost/detail/winapi/semaphore.hpp
+++ b/include/boost/detail/winapi/semaphore.hpp
@@ -19,12 +19,25 @@
 #if !defined( BOOST_USE_WINDOWS_H )
 extern "C" {
 #if !defined( BOOST_NO_ANSI_APIS )
+#if !defined( BOOST_PLAT_WINDOWS_RUNTIME_AVALIABLE )
 BOOST_SYMBOL_IMPORT boost::detail::winapi::HANDLE_ WINAPI
 CreateSemaphoreA(
     ::_SECURITY_ATTRIBUTES* lpSemaphoreAttributes,
     boost::detail::winapi::LONG_ lInitialCount,
     boost::detail::winapi::LONG_ lMaximumCount,
     boost::detail::winapi::LPCSTR_ lpName);
+#endif
+
+#if BOOST_USE_WINAPI_VERSION >= BOOST_WINAPI_VERSION_WIN6
+BOOST_SYMBOL_IMPORT boost::detail::winapi::HANDLE_ WINAPI
+CreateSemaphoreExA(
+    ::_SECURITY_ATTRIBUTES* lpSemaphoreAttributes,
+    boost::detail::winapi::LONG_ lInitialCount,
+    boost::detail::winapi::LONG_ lMaximumCount,
+    boost::detail::winapi::LPCSTR_ lpName,
+    boost::detail::winapi::DWORD_ dwFlags,
+    boost::detail::winapi::DWORD_ dwDesiredAccess);
+#endif
 
 BOOST_SYMBOL_IMPORT boost::detail::winapi::HANDLE_ WINAPI
 OpenSemaphoreA(
@@ -39,6 +52,17 @@ CreateSemaphoreW(
     boost::detail::winapi::LONG_ lInitialCount,
     boost::detail::winapi::LONG_ lMaximumCount,
     boost::detail::winapi::LPCWSTR_ lpName);
+
+#if BOOST_USE_WINAPI_VERSION >= BOOST_WINAPI_VERSION_WIN6
+BOOST_SYMBOL_IMPORT boost::detail::winapi::HANDLE_ WINAPI
+CreateSemaphoreExW(
+    ::_SECURITY_ATTRIBUTES* lpSemaphoreAttributes,
+    boost::detail::winapi::LONG_ lInitialCount,
+    boost::detail::winapi::LONG_ lMaximumCount,
+    boost::detail::winapi::LPCWSTR_ lpName,
+    boost::detail::winapi::DWORD_ dwFlags,
+    boost::detail::winapi::DWORD_ dwDesiredAccess);
+#endif
 
 BOOST_SYMBOL_IMPORT boost::detail::winapi::HANDLE_ WINAPI
 OpenSemaphoreW(
@@ -64,22 +88,61 @@ using ::OpenSemaphoreA;
 using ::OpenSemaphoreW;
 using ::ReleaseSemaphore;
 
+#if defined( BOOST_USE_WINDOWS_H )
+
+const DWORD_ SEMAPHORE_ALL_ACCESS_ = SEMAPHORE_ALL_ACCESS;
+
+#else // defined( BOOST_USE_WINDOWS_H )
+
+const DWORD_ SEMAPHORE_ALL_ACCESS_ = 0x1F0003;
+
+#endif // defined( BOOST_USE_WINDOWS_H )
+
+const DWORD_ semaphore_all_access = SEMAPHORE_ALL_ACCESS_;
+
+
 #if !defined( BOOST_NO_ANSI_APIS )
 BOOST_FORCEINLINE HANDLE_ CreateSemaphoreA(SECURITY_ATTRIBUTES_* lpSemaphoreAttributes, LONG_ lInitialCount, LONG_ lMaximumCount, LPCSTR_ lpName)
 {
+#if !defined( BOOST_PLAT_WINDOWS_RUNTIME_AVALIABLE )
     return ::CreateSemaphoreA(reinterpret_cast< ::_SECURITY_ATTRIBUTES* >(lpSemaphoreAttributes), lInitialCount, lMaximumCount, lpName);
+#else
+    return ::CreateSemaphoreExA(reinterpret_cast< ::_SECURITY_ATTRIBUTES* >(lpSemaphoreAttributes), lInitialCount, lMaximumCount, lpName, 0, semaphore_all_access);
+#endif
 }
+
+#if BOOST_USE_WINAPI_VERSION >= BOOST_WINAPI_VERSION_WIN6
+BOOST_FORCEINLINE HANDLE_ CreateSemaphoreExA(SECURITY_ATTRIBUTES_* lpSemaphoreAttributes, LONG_ lInitialCount, LONG_ lMaximumCount, LPCSTR_ lpName, DWORD_ dwFlags, DWORD_ dwDesiredAccess)
+{
+    return ::CreateSemaphoreExA(reinterpret_cast< ::_SECURITY_ATTRIBUTES* >(lpSemaphoreAttributes), lInitialCount, lMaximumCount, lpName, dwFlags, dwDesiredAccess);
+}
+#endif
 #endif
 
 BOOST_FORCEINLINE HANDLE_ CreateSemaphoreW(SECURITY_ATTRIBUTES_* lpSemaphoreAttributes, LONG_ lInitialCount, LONG_ lMaximumCount, LPCWSTR_ lpName)
 {
+#if !defined( BOOST_PLAT_WINDOWS_RUNTIME_AVALIABLE )
     return ::CreateSemaphoreW(reinterpret_cast< ::_SECURITY_ATTRIBUTES* >(lpSemaphoreAttributes), lInitialCount, lMaximumCount, lpName);
+#else
+    return ::CreateSemaphoreExW(reinterpret_cast< ::_SECURITY_ATTRIBUTES* >(lpSemaphoreAttributes), lInitialCount, lMaximumCount, lpName, 0, semaphore_all_access);
+#endif
 }
+
+#if BOOST_USE_WINAPI_VERSION >= BOOST_WINAPI_VERSION_WIN6
+BOOST_FORCEINLINE HANDLE_ CreateSemaphoreExW(SECURITY_ATTRIBUTES_* lpSemaphoreAttributes, LONG_ lInitialCount, LONG_ lMaximumCount, LPCWSTR_ lpName, DWORD_ dwFlags, DWORD_ dwDesiredAccess)
+{
+    return ::CreateSemaphoreExW(reinterpret_cast< ::_SECURITY_ATTRIBUTES* >(lpSemaphoreAttributes), lInitialCount, lMaximumCount, lpName, dwFlags, dwDesiredAccess);
+}
+#endif
 
 #if !defined( BOOST_NO_ANSI_APIS )
 BOOST_FORCEINLINE HANDLE_ create_semaphore(SECURITY_ATTRIBUTES_* lpSemaphoreAttributes, LONG_ lInitialCount, LONG_ lMaximumCount, LPCSTR_ lpName)
 {
+#if !defined( BOOST_PLAT_WINDOWS_RUNTIME_AVALIABLE )
     return ::CreateSemaphoreA(reinterpret_cast< ::_SECURITY_ATTRIBUTES* >(lpSemaphoreAttributes), lInitialCount, lMaximumCount, lpName);
+#else
+    return ::CreateSemaphoreExA(reinterpret_cast< ::_SECURITY_ATTRIBUTES* >(lpSemaphoreAttributes), lInitialCount, lMaximumCount, lpName, 0, semaphore_all_access);
+#endif
 }
 
 BOOST_FORCEINLINE HANDLE_ open_semaphore(DWORD_ dwDesiredAccess, BOOL_ bInheritHandle, LPCSTR_ lpName)
@@ -90,7 +153,11 @@ BOOST_FORCEINLINE HANDLE_ open_semaphore(DWORD_ dwDesiredAccess, BOOL_ bInheritH
 
 BOOST_FORCEINLINE HANDLE_ create_semaphore(SECURITY_ATTRIBUTES_* lpSemaphoreAttributes, LONG_ lInitialCount, LONG_ lMaximumCount, LPCWSTR_ lpName)
 {
+#if !defined( BOOST_PLAT_WINDOWS_RUNTIME_AVALIABLE )
     return ::CreateSemaphoreW(reinterpret_cast< ::_SECURITY_ATTRIBUTES* >(lpSemaphoreAttributes), lInitialCount, lMaximumCount, lpName);
+#else
+    return ::CreateSemaphoreExW(reinterpret_cast< ::_SECURITY_ATTRIBUTES* >(lpSemaphoreAttributes), lInitialCount, lMaximumCount, lpName, 0, semaphore_all_access);
+#endif
 }
 
 BOOST_FORCEINLINE HANDLE_ open_semaphore(DWORD_ dwDesiredAccess, BOOL_ bInheritHandle, LPCWSTR_ lpName)
@@ -100,10 +167,10 @@ BOOST_FORCEINLINE HANDLE_ open_semaphore(DWORD_ dwDesiredAccess, BOOL_ bInheritH
 
 BOOST_FORCEINLINE HANDLE_ create_anonymous_semaphore(SECURITY_ATTRIBUTES_* lpSemaphoreAttributes, LONG_ lInitialCount, LONG_ lMaximumCount)
 {
-#ifdef BOOST_NO_ANSI_APIS
+#if !defined( BOOST_PLAT_WINDOWS_RUNTIME_AVALIABLE )
     return ::CreateSemaphoreW(reinterpret_cast< ::_SECURITY_ATTRIBUTES* >(lpSemaphoreAttributes), lInitialCount, lMaximumCount, 0);
 #else
-    return ::CreateSemaphoreA(reinterpret_cast< ::_SECURITY_ATTRIBUTES* >(lpSemaphoreAttributes), lInitialCount, lMaximumCount, 0);
+    return ::CreateSemaphoreExW(reinterpret_cast< ::_SECURITY_ATTRIBUTES* >(lpSemaphoreAttributes), lInitialCount, lMaximumCount, 0, 0, semaphore_all_access);
 #endif
 }
 


### PR DESCRIPTION
Add CreateMutexEx, CreateSemaphoreEx and CreateEventEx function
declarations and define related symbols.

Force the related API wrapper to use the new APIs when compiling for
the Windows Runtime platform.