### PR TITLE
Fix compilation with WIN32_LEAN_AND_MEAN

### DIFF
--- a/include/boost/detail/winapi/crypt.hpp
+++ b/include/boost/detail/winapi/crypt.hpp
@@ -12,8 +12,8 @@
 
 #include <boost/detail/winapi/basic_types.hpp>
 #include <boost/detail/winapi/detail/cast_ptr.hpp>
-#if defined( BOOST_USE_WINDOWS_H ) && defined( BOOST_WINAPI_IS_MINGW )
-// MinGW does not include this header as part of windows.h
+#if defined( BOOST_USE_WINDOWS_H )
+// This header is not always included as part of windows.h
 #include <wincrypt.h>
 #endif
 


### PR DESCRIPTION
If WIN32_LEAN_AND_MEAN is defined, wincrypt.h is not included in windows.h.
Always explicitly including wincrypt.h when BOOST_USE_WINDOWS_H is defined
doesn't hurt anyway, as this is where the functions used here are defined.

Tested with clang-cl and Windows SDK 10.