### PR TITLE
Additions to WinApi

### DIFF
--- a/include/boost/detail/winapi/GetSystemDirectory.hpp
+++ b/include/boost/detail/winapi/GetSystemDirectory.hpp
@@ -1,0 +1,58 @@
+/*
+ * GetSystemDirectory.hpp
+ *
+ *  Created on: 11.10.2015
+ *      Author: Klemens
+ */
+
+#ifndef BOOST_DETAIL_WINAPI_GETSYSTEMDIRECTORY_HPP_
+#define BOOST_DETAIL_WINAPI_GETSYSTEMDIRECTORY_HPP_
+
+#include <boost/detail/winapi/basic_types.hpp>
+#include <boost/detail/winapi/tchar.hpp>
+
+namespace boost
+{
+namespace detail
+{
+namespace winapi
+{
+extern "C" {
+
+#if defined( BOOST_USE_WINDOWS_H )
+
+using ::GetSystemDirectoryA;
+using ::GetSystemDirectoryW;
+#else
+
+__declspec(dllimport) unsigned int WINAPI GetSystemDirectoryA (LPSTR_ lpBuffer,  unsigned int uSize);
+__declspec(dllimport) unsigned int WINAPI GetSystemDirectoryW (LPWSTR_ lpBuffer, unsigned int uSize);
+
+
+#if defined(UNICODE) && !defined(GetSystemDirectory)
+inline unsigned int GetSystemDirectory (LPWSTR_ lpBuffer,  unsigned int uSize)
+{
+	return GetSystemDirectoryW(lpBuffer, uSize);
+}
+
+
+#elif !defined(GetSystemDirectory)
+inline unsigned int GetSystemDirectory (LPSTR_ lpBuffer,  unsigned int uSize)
+{
+	return GetSystemDirectoryA(lpBuffer, uSize);
+}
+
+#endif
+#endif
+}
+
+}
+
+}
+}
+
+
+
+
+
+#endif /* BOOST_DETAIL_WINAPI_GETSYSTEMDIRECTORY_HPP_ */

--- a/include/boost/detail/winapi/environment.hpp
+++ b/include/boost/detail/winapi/environment.hpp
@@ -1,0 +1,98 @@
+/*
+ * environment.hpp
+ *
+ *  Created on: 11.10.2015
+ *      Author: Klemens Morgenstern
+ */
+
+#ifndef BOOST_DETAIL_WINAPI_ENVIRONMENT_HPP_
+#define BOOST_DETAIL_WINAPI_ENVIRONMENT_HPP_
+
+#include <boost/detail/winapi/basic_types.hpp>
+
+
+namespace boost
+{
+namespace detail
+{
+namespace winapi
+{
+extern "C" {
+
+#if defined(BOOST_USE_WINDOWS_H)
+
+const DWORD_ debug_process                    = DEBUG_PROCESS                   ;
+const DWORD_ debug_only_this_process          = DEBUG_ONLY_THIS_PROCESS         ;
+const DWORD_ create_suspended                 = CREATE_SUSPENDED                ;
+const DWORD_ detached_process                 = DETACHED_PROCESS                ;
+const DWORD_ create_new_console               = CREATE_NEW_CONSOLE              ;
+const DWORD_ normal_priority_class            = NORMAL_PRIORITY_CLASS           ;
+const DWORD_ idle_priority_class              = IDLE_PRIORITY_CLASS             ;
+const DWORD_ high_priority_class              = HIGH_PRIORITY_CLASS             ;
+const DWORD_ realtime_priority_class          = REALTIME_PRIORITY_CLASS         ;
+const DWORD_ create_new_process_group         = CREATE_NEW_PROCESS_GROUP        ;
+const DWORD_ create_unicode_environment       = CREATE_UNICODE_ENVIRONMENT      ;
+const DWORD_ create_separate_wow_vdm          = CREATE_SEPARATE_WOW_VDM         ;
+const DWORD_ create_shared_wow_vdm            = CREATE_SHARED_WOW_VDM           ;
+const DWORD_ create_forcedos                  = CREATE_FORCEDOS                 ;
+const DWORD_ below_normal_priority_class      = BELOW_NORMAL_PRIORITY_CLASS     ;
+const DWORD_ above_normal_priority_class      = ABOVE_NORMAL_PRIORITY_CLASS     ;
+const DWORD_ inherit_parent_affinity          = INHERIT_PARENT_AFFINITY         ;
+const DWORD_ inherit_caller_priority          = INHERIT_CALLER_PRIORITY         ;
+const DWORD_ create_protected_process         = CREATE_PROTECTED_PROCESS        ;
+const DWORD_ extended_startupinfo_present     = EXTENDED_STARTUPINFO_PRESENT    ;
+const DWORD_ process_mode_background_begin    = PROCESS_MODE_BACKGROUND_BEGIN   ;
+const DWORD_ process_mode_background_end      = PROCESS_MODE_BACKGROUND_END     ;
+const DWORD_ create_breakaway_from_job        = CREATE_BREAKAWAY_FROM_JOB       ;
+const DWORD_ create_preserve_code_authz_level = CREATE_PRESERVE_CODE_AUTHZ_LEVEL;
+const DWORD_ create_default_error_mode        = CREATE_DEFAULT_ERROR_MODE       ;
+const DWORD_ create_no_window                 = CREATE_NO_WINDOW                ;
+const DWORD_ profile_user                     = PROFILE_USER                    ;
+const DWORD_ profile_kernel                   = PROFILE_KERNEL                  ;
+const DWORD_ profile_server                   = PROFILE_SERVER                  ;
+const DWORD_ create_ignore_system_default     = CREATE_IGNORE_SYSTEM_DEFAULT    ;
+
+#else
+
+const DWORD_ debug_process                    = 0x1        ;
+const DWORD_ debug_only_this_process          = 0x2        ;
+const DWORD_ create_suspended                 = 0x4        ;
+const DWORD_ detached_process                 = 0x8        ;
+const DWORD_ create_new_console               = 0x10       ;
+const DWORD_ normal_priority_class            = 0x20       ;
+const DWORD_ idle_priority_class              = 0x40       ;
+const DWORD_ high_priority_class              = 0x80       ;
+const DWORD_ realtime_priority_class          = 0x100      ;
+const DWORD_ create_new_process_group         = 0x200      ;
+const DWORD_ create_unicode_environment       = 0x400      ;
+const DWORD_ create_separate_wow_vdm          = 0x800      ;
+const DWORD_ create_shared_wow_vdm            = 0x1000     ;
+const DWORD_ create_forcedos                  = 0x2000     ;
+const DWORD_ below_normal_priority_class      = 0x4000     ;
+const DWORD_ above_normal_priority_class      = 0x8000     ;
+const DWORD_ inherit_parent_affinity          = 0x10000    ;
+const DWORD_ inherit_caller_priority          = 0x20000    ;
+const DWORD_ create_protected_process         = 0x40000    ;
+const DWORD_ extended_startupinfo_present     = 0x80000    ;
+const DWORD_ process_mode_background_begin    = 0x100000   ;
+const DWORD_ process_mode_background_end      = 0x200000   ;
+const DWORD_ create_breakaway_from_job        = 0x1000000  ;
+const DWORD_ create_preserve_code_authz_level = 0x2000000  ;
+const DWORD_ create_default_error_mode        = 0x4000000  ;
+const DWORD_ create_no_window                 = 0x8000000  ;
+const DWORD_ profile_user                     = 0x10000000 ;
+const DWORD_ profile_kernel                   = 0x20000000 ;
+const DWORD_ profile_server                   = 0x40000000 ;
+const DWORD_ create_ignore_system_default     = 0x80000000 ;
+}
+
+
+#endif
+
+}
+
+}
+}
+
+
+#endif /* BOOST_DETAIL_WINAPI_ENVIRONMENT_HPP_ */

--- a/include/boost/detail/winapi/handle_info.hpp
+++ b/include/boost/detail/winapi/handle_info.hpp
@@ -1,0 +1,52 @@
+/*
+ * handleapi.hpp
+ *
+ *  Created on: 11.10.2015
+ *      Author: Klemens Morgenstern
+ */
+
+#ifndef BOOST_DETAIL_HANDLEAPI_HPP_
+#define BOOST_DETAIL_HANDLEAPI_HPP_
+
+#include <boost/detail/winapi/basic_types.hpp>
+#include <boost/detail/winapi/config.hpp>
+#include <boost/detail/winapi/handles.hpp>
+
+
+namespace boost
+{
+namespace detail
+{
+namespace winapi
+{
+extern "C" {
+
+#if defined( BOOST_USE_WINDOWS_H )
+
+using ::GetHandleInformation;
+using ::SetHandleInformation;
+
+const DWORD_ handle_flag_inherit = HANDLE_FLAG_INHERIT;
+const DWORD_ handle_flag_protect_from_close = HANDLE_FLAG_PROTECT_FROM_CLOSE;
+
+#else
+
+const DWORD_ handle_flag_inherit 			= 0x1;
+const DWORD_ handle_flag_protect_from_close = 0x2;
+
+__declspec(dllimport) int WINAPI GetHandleInformation (HANDLE_ hObject, DWORD_* lpdwFlags);
+__declspec(dllimport) int WINAPI SetHandleInformation (HANDLE_ hObject, DWORD_ dwMask, DWORD_ dwFlags);
+
+}
+
+
+#endif
+
+}
+
+}
+}
+
+
+
+#endif /* BOOST_DETAIL_HANDLEAPI_HPP_ */

--- a/include/boost/detail/winapi/named_pipe_api.hpp
+++ b/include/boost/detail/winapi/named_pipe_api.hpp
@@ -1,0 +1,99 @@
+/*
+ * namepd_pipe_api.hpp
+ *
+ *  Created on: 11.10.2015
+ *      Author: Klemens Morgenstern
+ */
+
+#ifndef BOOST_DETAIL_WINAPI_NAMED_PIPE_API_HPP_
+#define BOOST_DETAIL_WINAPI_NAMED_PIPE_API_HPP_
+
+#include <boost/detail/winapi/basic_types.hpp>
+#include <boost/detail/winapi/config.hpp>
+#include <boost/detail/winapi/security.hpp>
+
+
+namespace boost
+{
+namespace detail
+{
+namespace winapi
+{
+extern "C" {
+
+#if defined( BOOST_USE_WINDOWS_H )
+using ::ImpersonateNamedPipeClient;
+using ::CreatePipe;
+using ::ConnectNamedPipe;
+using ::DisconnectNamedPipe;
+using ::SetNamedPipeHandleState;
+using ::PeekNamedPipe;
+using ::TransactNamedPipe;
+using ::CreateNamedPipeW;
+using ::WaitNamedPipeW;
+#if BOOST_USE_WINAPI_VERSION >= BOOST_WINAPI_VERSION_WIN6
+using ::GetNamedPipeClientComputerNameW;
+#endif
+typedef ::OVERLAPPED   OVERLAPPED_;
+typedef ::LPOVERLAPPED LPOVERLAPPED_;
+#else
+
+struct OVERLAPPED_ {
+  ULONG_PTR_ Internal;
+  ULONG_PTR_ InternalHigh;
+  union {
+    struct {
+      DWORD_ Offset;
+      DWORD_ OffsetHigh;
+    } ;
+    PVOID_  Pointer;
+  } ;
+  HANDLE_    hEvent;
+};
+
+typedef OVERLAPPED_ *LPOVERLAPPED_;
+
+__declspec(dllimport) int     WINAPI ImpersonateNamedPipeClient (HANDLE_ hNamedPipe);
+__declspec(dllimport) int     WINAPI CreatePipe (HANDLE_* hReadPipe, HANDLE_* hWritePipe, LPSECURITY_ATTRIBUTES_ lpPipeAttributes, DWORD_ nSize);
+__declspec(dllimport) int     WINAPI ConnectNamedPipe (HANDLE_ hNamedPipe, LPOVERLAPPED_ lpOverlapped);
+__declspec(dllimport) int     WINAPI DisconnectNamedPipe (HANDLE_ hNamedPipe);
+__declspec(dllimport) int     WINAPI SetNamedPipeHandleState (HANDLE_ hNamedPipe, DWORD_* lpMode, DWORD_* lpMaxCollectionCount, DWORD_* lpCollectDataTimeout);
+__declspec(dllimport) int     WINAPI PeekNamedPipe (HANDLE_ hNamedPipe, LPVOID_ lpBuffer, DWORD_ nBufferSize, DWORD_* lpBytesRead, DWORD_* lpTotalBytesAvail, DWORD_* lpBytesLeftThisMessage);
+__declspec(dllimport) int     WINAPI TransactNamedPipe (HANDLE_ hNamedPipe, LPVOID_ lpInBuffer, DWORD_ nInBufferSize, LPVOID_ lpOutBuffer, DWORD_ nOutBufferSize, DWORD_* lpBytesRead, LPOVERLAPPED_ lpOverlapped);
+__declspec(dllimport) HANDLE_ WINAPI CreateNamedPipeW (LPCWSTR_ lpName, DWORD_ dwOpenMode, DWORD_ dwPipeMode, DWORD_ nMaxInstances, DWORD_ nOutBufferSize, DWORD_ nInBufferSize, DWORD_ nDefaultTimeOut, LPSECURITY_ATTRIBUTES_ lpSecurityAttributes);
+__declspec(dllimport) int 	  WINAPI WaitNamedPipeW (LPCWSTR_ lpNamedPipeName, DWORD_ nTimeOut);
+
+#if BOOST_USE_WINAPI_VERSION >= BOOST_WINAPI_VERSION_WIN6
+  WINBASEAPI int WINAPI GetNamedPipeClientComputerNameW (HANDLE_ Pipe, LPWSTR_ ClientComputerName, ULONG_ ClientComputerNameLength);
+#endif
+
+#if defined(UNICODE) && !defined(CreateNamedPipe) && !defined(WaitNamedPipe)
+inline HANDLE_ CreateNamedPipe(LPCWSTR_ lpName, DWORD_ dwOpenMode, DWORD_ dwPipeMode, DWORD_ nMaxInstances, DWORD_ nOutBufferSize, DWORD_ nInBufferSize, DWORD_ nDefaultTimeOut, LPSECURITY_ATTRIBUTES_ lpSecurityAttributes)
+{
+	return CreateNamedPipeW(lpName, dwOpenMode, dwPipeMode, nMaxInstances, nOutBufferSize, nInBufferSize, nDefaultTimeOut, lpSecurityAttributes);
+}
+
+inline int WaitNamedPipe(LPCWSTR_ lpNamedPipeName, DWORD_ nTimeOut)
+{
+	return WaitNamedPipeW(lpNamedPipeName, nTimeOut);
+}
+#if (BOOST_USE_WINAPI_VERSION >= BOOST_WINAPI_VERSION_WIN6) && !defined(GetNamedPipeClientComputerName)
+
+inline int GetNamedPipeClientComputerName(HANDLE_ Pipe, LPWSTR ClientComputerName, ULONG ClientComputerNameLength)
+{
+	return GetNamedPipeClientComputerNameW(Pipe, ClientComputerName, ClientComputerNameLength);
+}
+#endif
+#endif
+#endif
+}
+
+
+
+}
+
+}
+}
+
+
+#endif /* BOOST_DETAIL_WINAPI_NAMED_PIPE_API_HPP_ */

--- a/include/boost/detail/winapi/process_api.hpp
+++ b/include/boost/detail/winapi/process_api.hpp
@@ -1,0 +1,65 @@
+/*
+ * HANDLE_api.hpp
+ *
+ *  Created on: 11.10.2015
+ *      Author: Klemens Morgenstern
+ */
+
+#ifndef BOOST_DETAIL_PROCESS_API_HPP_
+#define BOOST_DETAIL_PROCESS_API_HPP_
+
+#include <boost/detail/winapi/config.hpp>
+#include <boost/detail/winapi/basic_types.hpp>
+#include <boost/detail/winapi/security.hpp>
+#include <boost/detail/winapi/process_info.hpp>
+
+namespace boost
+{
+namespace detail
+{
+namespace winapi
+{
+extern "C" {
+
+#if defined( BOOST_USE_WINDOWS_H )
+//|| defined( CreateProcess )
+using ::GetExitCodeProcess;
+using ::ExitProcess;
+using ::TerminateProcess;
+using ::CreateProcessA;
+using ::CreateProcessW;
+
+#else
+
+__declspec(dllimport) __declspec (noreturn) void WINAPI ExitProcess (unsigned int uExitCode);
+__declspec(dllimport) int WINAPI TerminateProcess 	(HANDLE_ hProcess, unsigned int uExitCode);
+__declspec(dllimport) int WINAPI GetExitCodeProcess (HANDLE_ hProcess, DWORD_* lpExitCode);
+
+__declspec(dllimport) int WINAPI CreateProcessA (LPCSTR_ lpApplicationName,  LPSTR_ lpCommandLine, LPSECURITY_ATTRIBUTES_ lpProcessAttributes, LPSECURITY_ATTRIBUTES_ lpThreadAttributes, int bInheritHandles, DWORD_ dwCreationFlags, LPVOID_ lpEnvironment, LPCSTR_ lpCurrentDirectory,   STARTUPINFOA_* lpStartupInfo, PROCESS_INFORMATION_* lpProcessInformation);
+__declspec(dllimport) int WINAPI CreateProcessW (LPCWSTR_ lpApplicationName, LPWSTR_ lpCommandLine, LPSECURITY_ATTRIBUTES_ lpProcessAttributes, LPSECURITY_ATTRIBUTES_ lpThreadAttributes, int bInheritHandles, DWORD_ dwCreationFlags, LPVOID_ lpEnvironment, LPCWSTR_ lpCurrentDirectory, STARTUPINFOW_* lpStartupInfo, PROCESS_INFORMATION_* lpProcessInformation);
+
+
+
+#if defined(UNICODE) && !defined(CreateProcess)
+inline static int CreateProcess (LPCWSTR_ lpApplicationName, LPWSTR_ lpCommandLine, LPSECURITY_ATTRIBUTES_ lpProcessAttributes, LPSECURITY_ATTRIBUTES_ lpThreadAttributes, int bInheritHandles, DWORD_ dwCreationFlags, LPVOID_ lpEnvironment, LPCWSTR_ lpCurrentDirectory, STARTUPINFOW_* lpStartupInfo, PROCESS_INFORMATION_* lpProcessInformation)
+{
+	return CreateProcessW (lpApplicationName, lpCommandLine, lpProcessAttributes, lpThreadAttributes, bInheritHandles, dwCreationFlags, lpEnvironment, lpCurrentDirectory,  lpStartupInfo,  lpProcessInformation);
+}
+
+#elif !defined(CreateProcess)
+inline static int CreateProcess (LPCSTR_ lpApplicationName,  LPSTR_ lpCommandLine, LPSECURITY_ATTRIBUTES_ lpProcessAttributes, LPSECURITY_ATTRIBUTES_ lpThreadAttributes, int bInheritHandles, DWORD_ dwCreationFlags, LPVOID_ lpEnvironment, LPCSTR_ lpCurrentDirectory,   STARTUPINFOA_* lpStartupInfo, PROCESS_INFORMATION_* lpProcessInformation)
+{
+	return CreateProcessA (lpApplicationName, lpCommandLine, lpProcessAttributes, lpThreadAttributes, bInheritHandles, dwCreationFlags, lpEnvironment, lpCurrentDirectory,  lpStartupInfo,  lpProcessInformation);
+}
+#endif //UNICODE
+#endif //BOOST_USE_WINDOWS_H
+}
+
+}
+
+}
+}
+
+
+
+#endif /* BOOST_DETAIL_HANDLE_API_HPP_ */

--- a/include/boost/detail/winapi/process_info.hpp
+++ b/include/boost/detail/winapi/process_info.hpp
@@ -1,0 +1,107 @@
+/*
+ * process_info.hpp
+ *
+ *  Created on: 11.10.2015
+ *      Author: Klemens
+ */
+
+#ifndef BOOST_DETAIL_WINAPI_PROCESS_INFO_HPP_
+#define BOOST_DETAIL_WINAPI_PROCESS_INFO_HPP_
+
+#include <boost/detail/winapi/basic_types.hpp>
+#include <boost/detail/winapi/config.hpp>
+#include <boost/detail/winapi/handles.hpp>
+
+
+namespace boost
+{
+namespace detail
+{
+namespace winapi
+{
+extern "C" {
+
+#if defined( BOOST_USE_WINDOWS_H )
+typedef ::PROCESS_INFORMATION PROCESS_INFORMATION_;
+typedef ::STARTUPINFOA STARTUPINFOA_;
+typedef ::STARTUPINFOW STARTUPINFOW_;
+typedef ::STARTUPINFOEX STARTUPINFOEX;
+#else
+
+struct PROCESS_INFORMATION_
+{
+    HANDLE_ hProcess;
+    HANDLE_ hThread;
+    DWORD_ dwProcessId;
+    DWORD_ dwThreadId;
+};
+
+
+struct STARTUPINFOA_ {
+  DWORD_ cb;
+  LPSTR_ lpReserved;
+  LPSTR_ lpDesktop;
+  LPSTR_ lpTitle;
+  DWORD_ dwX;
+  DWORD_ dwY;
+  DWORD_ dwXSize;
+  DWORD_ dwYSize;
+  DWORD_ dwXCountChars;
+  DWORD_ dwYCountChars;
+  DWORD_ dwFillAttribute;
+  DWORD_ dwFlags;
+  WORD_ wShowWindow;
+  WORD_ cbReserved2;
+  BYTE_ *lpReserved2;
+  HANDLE_ hStdInput;
+  HANDLE_ hStdOutput;
+  HANDLE_ hStdError;
+};
+
+struct STARTUPINFOW_ {
+  DWORD cb;
+  LPWSTR_ lpReserved;
+  LPWSTR_ lpDesktop;
+  LPWSTR_ lpTitle;
+  DWORD_ dwX;
+  DWORD_ dwY;
+  DWORD_ dwXSize;
+  DWORD_ dwYSize;
+  DWORD_ dwXCountChars;
+  DWORD_ dwYCountChars;
+  DWORD_ dwFillAttribute;
+  DWORD_ dwFlags;
+  WORD_ wShowWindow;
+  WORD_ cbReserved2;
+  BYTE_ *lpReserved2;
+  HANDLE_ hStdInput;
+  HANDLE_ hStdOutput;
+  HANDLE_ hStdError;
+} ;
+
+
+#if defined(UNICODE)
+typedef STARTUPINFOW_ STARTUPINFO_;
+#else
+typedef STARTUPINFOA_ STARTUPINFO_;
+#endif
+
+#if defined( BOOST_USE_WINDOWS_H )
+typedef ::STARTUPINFOEX STARTUPINFOEX_;
+
+#else
+
+typedef struct PROC_THREAD_ATTRIBUTE_LIST_ *PPROC_THREAD_ATTRIBUTE_LIST_;
+
+
+struct STARTUPINFOEX_ {
+  STARTUPINFO_                 StartupInfo;
+  PPROC_THREAD_ATTRIBUTE_LIST_ lpAttributeList;
+};
+
+#endif
+#endif
+}
+}}}
+
+#endif /* BOOST_DETAIL_WINAPI_PROCESS_INFO_HPP_ */

--- a/include/boost/detail/winapi/shell_api.hpp
+++ b/include/boost/detail/winapi/shell_api.hpp
@@ -1,0 +1,133 @@
+/*
+ * shell_api.hpp
+ *
+ *  Created on: 11.10.2015
+ *      Author: Klemens
+ */
+
+#ifndef BOOST_DETAIL_WINAPI_SHELL_API_HPP_
+#define BOOST_DETAIL_WINAPI_SHELL_API_HPP_
+
+#include <boost/detail/winapi/basic_types.hpp>
+#include <boost/detail/winapi/config.hpp>
+
+
+namespace boost
+{
+namespace detail
+{
+namespace winapi
+{
+extern "C" {
+
+#if defined( BOOST_USE_WINDOWS_H )
+
+const DWORD_ shgfi_icon 				= SHGFI_ICON 			;
+const DWORD_ shgfi_displayname 			= SHGFI_DISPLAYNAME 	;
+const DWORD_ shgfi_typename 			= SHGFI_TYPENAME 		;
+const DWORD_ shgfi_attributes 			= SHGFI_ATTRIBUTES 		;
+const DWORD_ shgfi_iconlocation 		= SHGFI_ICONLOCATION 	;
+const DWORD_ shgfi_exetype 				= SHGFI_EXETYPE 		;
+const DWORD_ shgfi_sysiconindex 		= SHGFI_SYSICONINDEX 	;
+const DWORD_ shgfi_linkoverlay 			= SHGFI_LINKOVERLAY 	;
+const DWORD_ shgfi_selected 			= SHGFI_SELECTED 		;
+const DWORD_ shgfi_attr_specified 		= SHGFI_ATTR_SPECIFIED 	;
+const DWORD_ shgfi_largeicon 			= SHGFI_LARGEICON 		;
+const DWORD_ shgfi_smallicon 			= SHGFI_SMALLICON 		;
+const DWORD_ shgfi_openicon 			= SHGFI_OPENICON 		;
+const DWORD_ shgfi_shelliconsize 		= SHGFI_SHELLICONSIZE 	;
+const DWORD_ shgfi_pidl 				= SHGFI_PIDL 			;
+const DWORD_ shgfi_usefileattributes	= SHGFI_USEFILEATTRIBUTES;
+const DWORD_ shgfi_addoverlays 			= SHGFI_ADDOVERLAYS 	;
+const DWORD_ shgfi_overlayindex 		= SHGFI_OVERLAYINDEX 	;
+const DWORD_ max_path = MAX_PATH;
+
+
+using ::SHGetFileInfoA;
+using ::SHGetFileInfoW;
+
+typedef ::SHFILEINFOA SHFILEINFOA_;
+typedef ::SHFILEINFOW SHFILEINFOW_;
+typedef ::ICON   ICON_;
+typedef ::HICON HICON_;
+#else
+
+struct ICON_ {};
+typedef ICON_ *HICON_;
+
+const DWORD_ max_path = 260;
+
+struct SHFILEINFOA_ {
+  HICON_ hIcon;
+  int iIcon;
+  DWORD_ dwAttributes;
+  CHAR_  szDisplayName[260];
+  CHAR_  szTypeName[80];
+} ;
+
+struct SHFILEINFOW_ {
+  HICON_ hIcon;
+  int iIcon;
+  DWORD_ dwAttributes;
+  WCHAR_ szDisplayName[260];
+  WCHAR_ szTypeName[80];
+};
+
+
+const DWORD_ shgfi_icon 			 =	0x000000100;
+const DWORD_ shgfi_displayname 		 =	0x000000200;
+const DWORD_ shgfi_typename 		 =	0x000000400;
+const DWORD_ shgfi_attributes 		 =	0x000000800;
+const DWORD_ shgfi_iconlocation 	 =	0x000001000;
+const DWORD_ shgfi_exetype 			 =	0x000002000;
+const DWORD_ shgfi_sysiconindex 	 =	0x000004000;
+const DWORD_ shgfi_linkoverlay 		 =	0x000008000;
+const DWORD_ shgfi_selected 		 =	0x000010000;
+const DWORD_ shgfi_attr_specified 	 =	0x000020000;
+const DWORD_ shgfi_largeicon 		 =	0x000000000;
+const DWORD_ shgfi_smallicon 		 =	0x000000001;
+const DWORD_ shgfi_openicon 		 =	0x000000002;
+const DWORD_ shgfi_shelliconsize 	 =	0x000000004;
+const DWORD_ shgfi_pidl 			 =	0x000000008;
+const DWORD_ shgfi_usefileattributes = 	0x000000010;
+const DWORD_ shgfi_addoverlays 		 =	0x000000020;
+const DWORD_ shgfi_overlayindex 	 =	0x000000040;
+
+__declspec(dllimport) DWORD_* WINAPI SHGetFileInfoA (LPCSTR_ pszPath,  DWORD_ dwFileAttributes, SHFILEINFOA_ *psfinsigned, unsigned int cbFileInfons, unsigned int uFlags);
+__declspec(dllimport) DWORD_* WINAPI SHGetFileInfoW (LPCWSTR_ pszPath, DWORD_ dwFileAttributes, SHFILEINFOW_ *psfinsigned, unsigned int cbFileInfons, unsigned int uFlags);
+
+
+}
+
+
+#endif
+
+
+#if defined(UNICODE) || defined(_UNICODE)
+typedef SHFILEINFOW_ SHFILEINFO_;
+inline DWORD_* SHGetFileInfo (LPCWSTR_ pszPath, DWORD_ dwFileAttributes, SHFILEINFOW_ *psfinsigned, unsigned int cbFileInfons, unsigned int uFlags)
+{
+	return SHGetFileInfoW(pszPath,  dwFileAttributes, psfinsigned, cbFileInfons, uFlags);
+}
+
+
+#else
+typedef SHFILEINFOA_ SHFILEINFO_;
+inline DWORD_* SHGetFileInfo (LPCSTR_ pszPath,  DWORD_ dwFileAttributes, SHFILEINFOA_ *psfinsigned, unsigned int cbFileInfons, unsigned int uFlags)
+{
+	return SHGetFileInfoA (pszPath,  dwFileAttributes, psfinsigned, cbFileInfons, uFlags);
+}
+
+
+
+
+#endif
+
+}
+
+}
+}
+
+
+
+#endif /* BOOST_DETAIL_WINAPI_SHELL_API_HPP_ */

--- a/include/boost/detail/winapi/show_windows.hpp
+++ b/include/boost/detail/winapi/show_windows.hpp
@@ -1,0 +1,90 @@
+/*
+ * show_windows.hpp
+ *
+ *  Created on: 11.10.2015
+ *      Author: Klemens Morgenstern
+ */
+
+#ifndef BOOST_DETAIL_WINAPI_SHOW_WINDOWS_HPP_
+#define BOOST_DETAIL_WINAPI_SHOW_WINDOWS_HPP_
+
+#include <boost/detail/winapi/basic_types.hpp>
+#include <boost/detail/winapi/config.hpp>
+
+
+namespace boost
+{
+namespace detail
+{
+namespace winapi
+{
+extern "C" {
+
+#if defined( BOOST_USE_WINDOWS_H )
+
+const DWOD_ sw_hide 			= SW_HIDE 			 	;
+const DWOD_ sw_shownormal 		= SW_SHOWNORMAL 		;
+const DWOD_ sw_normal 			= SW_NORMAL 			;
+const DWOD_ sw_showminimized 	= SW_SHOWMINIMIZED 	    ;
+const DWOD_ sw_showmaximized	= SW_SHOWMAXIMIZED	 	;
+const DWOD_ sw_maximize 		= SW_MAXIMIZE 		    ;
+const DWOD_ sw_shownoactivate 	= SW_SHOWNOACTIVATE 	;
+const DWOD_ sw_show 			= SW_SHOW 			 	;
+const DWOD_ sw_minimize 		= SW_MINIMIZE 		 	;
+const DWOD_ sw_showminnoactive  = SW_SHOWMINNOACTIVE  	;
+const DWOD_ sw_showna 			= SW_SHOWNA 			;
+const DWOD_ sw_restore 		 	= SW_RESTORE 		 	;
+const DWOD_ sw_showdefault 	 	= SW_SHOWDEFAULT 	 	;
+const DWOD_ sw_forceminimize 	= SW_FORCEMINIMIZE 	    ;
+const DWOD_ sw_max 			 	= SW_MAX 			 	;
+const DWOD_ hide_window 		= HIDE_WINDOW 		 	;
+const DWOD_ show_openwindow 	= SHOW_OPENWINDOW 	 	;
+const DWOD_ show_iconwindow 	= SHOW_ICONWINDOW 	 	;
+const DWOD_ show_fullscreen 	= SHOW_FULLSCREEN 	 	;
+const DWOD_ show_opennoactivate = SHOW_OPENNOACTIVATE 	;
+const DWOD_ sw_parentclosing 	= SW_PARENTCLOSING 	    ;
+const DWOD_ sw_otherzoom 		= SW_OTHERZOOM 		    ;
+const DWOD_ sw_parentopening 	= SW_PARENTOPENING 	    ;
+const DWOD_ sw_otherunzoom 	 	= SW_OTHERUNZOOM 	 	;
+
+
+
+#else
+
+const DWORD_ sw_hide 			 = 0 ;
+const DWORD_ sw_shownormal 		 = 1 ;
+const DWORD_ sw_normal 			 = 1 ;
+const DWORD_ sw_showminimized 	 = 2 ;
+const DWORD_ sw_showmaximized	 = 3 ;
+const DWORD_ sw_maximize 		 = 3 ;
+const DWORD_ sw_shownoactivate 	 = 4 ;
+const DWORD_ sw_show 			 = 5 ;
+const DWORD_ sw_minimize 		 = 6 ;
+const DWORD_ sw_showminnoactive  = 7 ;
+const DWORD_ sw_showna 			 = 8 ;
+const DWORD_ sw_restore 		 = 9 ;
+const DWORD_ sw_showdefault 	 = 10;
+const DWORD_ sw_forceminimize 	 = 11;
+const DWORD_ sw_max 			 = 11;
+const DWORD_ hide_window 		 = 0 ;
+const DWORD_ show_openwindow 	 = 1 ;
+const DWORD_ show_iconwindow 	 = 2 ;
+const DWORD_ show_fullscreen 	 = 3 ;
+const DWORD_ show_opennoactivate = 4 ;
+const DWORD_ sw_parentclosing 	 = 1 ;
+const DWORD_ sw_otherzoom 		 = 2 ;
+const DWORD_ sw_parentopening 	 = 3 ;
+const DWORD_ sw_otherunzoom 	 = 4 ;
+
+
+}
+
+
+#endif
+
+}
+
+}
+}
+
+#endif /* BOOST_DETAIL_WINAPI_SHOW_WINDOWS_HPP_ */

--- a/include/boost/detail/winapi/startf.hpp
+++ b/include/boost/detail/winapi/startf.hpp
@@ -1,0 +1,68 @@
+/*
+ * startf.hpp
+ *
+ *  Created on: 11.10.2015
+ *      Author: Klemens Morgenstern
+ */
+
+#ifndef BOOST_DETAIL_WINAPI_STARTF_HPP_
+#define BOOST_DETAIL_WINAPI_STARTF_HPP_
+
+#include <boost/detail/winapi/basic_types.hpp>
+#include <boost/detail/winapi/config.hpp>
+
+
+namespace boost
+{
+namespace detail
+{
+namespace winapi
+{
+extern "C" {
+
+#if defined( BOOST_USE_WINDOWS_H )
+
+const DWORD_ startf_useshowwindow 		= STARTF_USESHOWWINDOW 	;
+const DWORD_ startf_usesize 			= STARTF_USESIZE 		;
+const DWORD_ startf_useposition 		= STARTF_USEPOSITION 	;
+const DWORD_ startf_usecountchars 		= STARTF_USECOUNTCHARS 	;
+const DWORD_ startf_usefillattribute 	= STARTF_USEFILLATTRIBUTE;
+const DWORD_ startf_runfullscreen		= STARTF_RUNFULLSCREEN	;
+const DWORD_ startf_forceonfeedback 	= STARTF_FORCEONFEEDBACK ;
+const DWORD_ startf_forceofffeedback 	= STARTF_FORCEOFFFEEDBACK;
+const DWORD_ startf_usestdhandles 		= STARTF_USESTDHANDLES 	;
+const DWORD_ startf_usehotkey 			= STARTF_USEHOTKEY 		;
+const DWORD_ startf_titleislinkname 	= STARTF_TITLEISLINKNAME ;
+const DWORD_ startf_titleisappid 		= STARTF_TITLEISAPPID 	;
+const DWORD_ startf_preventpinning		= STARTF_PREVENTPINNING	;
+
+#else
+
+const DWORD_ startf_useshowwindow 		= 0x00000001;
+const DWORD_ startf_usesize 			= 0x00000002;
+const DWORD_ startf_useposition 		= 0x00000004;
+const DWORD_ startf_usecountchars 		= 0x00000008;
+const DWORD_ startf_usefillattribute 	= 0x00000010;
+const DWORD_ startf_runfullscreen		= 0x00000020;
+const DWORD_ startf_forceonfeedback 	= 0x00000040;
+const DWORD_ startf_forceofffeedback 	= 0x00000080;
+const DWORD_ startf_usestdhandles 		= 0x00000100;
+const DWORD_ startf_usehotkey 			= 0x00000200;
+const DWORD_ startf_titleislinkname 	= 0x00000800;
+const DWORD_ startf_titleisappid 		= 0x00001000;
+const DWORD_ startf_preventpinning		= 0x00002000;
+}
+
+
+#endif
+
+}
+
+}
+}
+
+//STARTF_USESTDHANDLES
+
+
+
+#endif /* BOOST_DETAIL_WINAPI_STARTF_HPP_ */

--- a/include/boost/detail/winapi/tchar.hpp
+++ b/include/boost/detail/winapi/tchar.hpp
@@ -1,0 +1,44 @@
+/*
+ * string.hpp
+ *
+ *  Created on: 11.10.2015
+ *      Author: Klemens
+ */
+
+#ifndef BOOST_DETAIL_WINAPI_TCHAR_HPP_
+#define BOOST_DETAIL_WINAPI_TCHAR_HPP_
+
+#include <boost/detail/winapi/basic_types.hpp>
+
+namespace boost
+{
+namespace detail
+{
+namespace winapi
+{
+extern "C" {
+
+#if defined( BOOST_USE_WINDOWS_H )
+
+typedef ::TCHAR TCHAR_;
+
+#else
+
+#if defined(UNICODE)
+typedef wchar_t TCHAR_;
+#else
+typedef char TCHAR_;
+#endif
+}
+
+
+#endif
+
+}
+
+}
+}
+
+
+
+#endif /* BOOST_DETAIL_WINAPI_TCHAR_HPP_ */


### PR DESCRIPTION
I removed all direct inclusions of windows.h in boost/process and replaced them in the boost.winapi style. I hope this library would be the right place for those additions, so boost.process can use them. 