### PR TITLE
Pragma message is only available for GCC > 4.3

### DIFF
--- a/include/boost/detail/winapi/GetCurrentProcess.hpp
+++ b/include/boost/detail/winapi/GetCurrentProcess.hpp
@@ -16,7 +16,7 @@
 #pragma once
 #endif
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) && (((__GNUC__*100)+__GNUC_MINOR__) > 403)
 #pragma message "This header is deprecated, use boost/detail/winapi/get_current_process.hpp instead."
 #elif defined(_MSC_VER)
 #pragma message("This header is deprecated, use boost/detail/winapi/get_current_process.hpp instead.")

--- a/include/boost/detail/winapi/GetCurrentThread.hpp
+++ b/include/boost/detail/winapi/GetCurrentThread.hpp
@@ -16,7 +16,7 @@
 #pragma once
 #endif
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) && (((__GNUC__*100)+__GNUC_MINOR__) > 403)
 #pragma message "This header is deprecated, use boost/detail/winapi/get_current_thread.hpp instead."
 #elif defined(_MSC_VER)
 #pragma message("This header is deprecated, use boost/detail/winapi/get_current_thread.hpp instead.")

--- a/include/boost/detail/winapi/GetLastError.hpp
+++ b/include/boost/detail/winapi/GetLastError.hpp
@@ -16,7 +16,7 @@
 #pragma once
 #endif
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) && (((__GNUC__*100)+__GNUC_MINOR__) > 403)
 #pragma message "This header is deprecated, use boost/detail/winapi/get_last_error.hpp instead."
 #elif defined(_MSC_VER)
 #pragma message("This header is deprecated, use boost/detail/winapi/get_last_error.hpp instead.")

--- a/include/boost/detail/winapi/GetProcessTimes.hpp
+++ b/include/boost/detail/winapi/GetProcessTimes.hpp
@@ -15,7 +15,7 @@
 #pragma once
 #endif
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) && (((__GNUC__*100)+__GNUC_MINOR__) > 403)
 #pragma message "This header is deprecated, use boost/detail/winapi/get_process_times.hpp instead."
 #elif defined(_MSC_VER)
 #pragma message("This header is deprecated, use boost/detail/winapi/get_process_times.hpp instead.")

--- a/include/boost/detail/winapi/GetThreadTimes.hpp
+++ b/include/boost/detail/winapi/GetThreadTimes.hpp
@@ -16,7 +16,7 @@
 #pragma once
 #endif
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) && (((__GNUC__*100)+__GNUC_MINOR__) > 403)
 #pragma message "This header is deprecated, use boost/detail/winapi/get_thread_times.hpp instead."
 #elif defined(_MSC_VER)
 #pragma message("This header is deprecated, use boost/detail/winapi/get_thread_times.hpp instead.")


### PR DESCRIPTION
Just a trivial patch to silence warnings and allow -Werror in old GCCs