### PR TITLE
added GetFileInformationByHandle

### DIFF
--- a/include/boost/detail/winapi/file_management.hpp
+++ b/include/boost/detail/winapi/file_management.hpp
@@ -157,7 +157,17 @@ SetFilePointer(
     boost::detail::winapi::LONG_ lpDistanceToMove,
     boost::detail::winapi::PLONG_ lpDistanceToMoveHigh,
     boost::detail::winapi::DWORD_ dwMoveMethod);
+
+struct _BY_HANDLE_FILE_INFORMATION;
+
+BOOST_SYMBOL_IMPORT boost::detail::winapi::BOOL_ WINAPI
+GetFileInformationByHandle(
+    boost::detail::winapi::HANDLE_ hFile,
+    ::_BY_HANDLE_FILE_INFORMATION *lpFileInformation);
+
 }
+
+
 #endif
 
 namespace boost {
@@ -358,6 +368,21 @@ typedef struct BOOST_DETAIL_WINAPI_MAY_ALIAS _WIN32_FIND_DATAW {
 #endif
 } WIN32_FIND_DATAW_, *PWIN32_FIND_DATAW_, *LPWIN32_FIND_DATAW_;
 
+typedef struct BOOST_DETAIL_WINAPI_MAY_ALIAS _BY_HANDLE_FILE_INFORMATION {
+    DWORD_ dwFileAttributes;
+    FILETIME_ ftCreationTime;
+    FILETIME_ ftLastAccessTime;
+    FILETIME_ ftLastWriteTime;
+    DWORD_ dwVolumeSerialNumber;
+    DWORD_ nFileSizeHigh;
+    DWORD_ nFileSizeLow;
+    DWORD_ nNumberOfLinks;
+    DWORD_ nFileIndexHigh;
+    DWORD_ nFileIndexLow;
+} BY_HANDLE_FILE_INFORMATION_;
+
+
+
 BOOST_FORCEINLINE HANDLE_ FindFirstFileW(LPCWSTR_ lpFileName, WIN32_FIND_DATAW_* lpFindFileData)
 {
     return ::FindFirstFileW(lpFileName, reinterpret_cast< ::_WIN32_FIND_DATAW* >(lpFindFileData));
@@ -504,8 +529,12 @@ BOOST_FORCEINLINE DWORD_ get_file_attributes(LPCWSTR_ lpFileName)
     return ::GetFileAttributesW(lpFileName);
 }
 
-}
-}
+BOOST_FORCEINLINE BOOL_ GetFileInformationByHandle(HANDLE_ h, BY_HANDLE_FILE_INFORMATION_* info)
+{
+	return ::GetFileInformationByHandle(h, reinterpret_cast<::_BY_HANDLE_FILE_INFORMATION*>(info));
 }
 
+}
+}
+}
 #endif // BOOST_DETAIL_WINAPI_FILE_MANAGEMENT_HPP


### PR DESCRIPTION
I added the function, because my NtQueryHandle workaround doesn't work properly, but since this is the right way to compare file handles (which pipes are)