### PR TITLE
Fix CryptReleaseContext signature for Windows 2000 (#11896)

### DIFF
--- a/include/boost/detail/winapi/crypt.hpp
+++ b/include/boost/detail/winapi/crypt.hpp
@@ -98,10 +98,17 @@ CryptGenRandom(
     boost::detail::winapi::DWORD_ dwLen,
     boost::detail::winapi::BYTE_ *pbBuffer);
 
+#if BOOST_USE_WINAPI_VERSION >= BOOST_WINAPI_VERSION_WINXP
 BOOST_SYMBOL_IMPORT boost::detail::winapi::BOOL_ WINAPI
 CryptReleaseContext(
     boost::detail::winapi::HCRYPTPROV_ hProv,
     boost::detail::winapi::DWORD_ dwFlags);
+#else
+BOOST_SYMBOL_IMPORT boost::detail::winapi::BOOL_ WINAPI
+CryptReleaseContext(
+    boost::detail::winapi::HCRYPTPROV_ hProv,
+    boost::detail::winapi::ULONG_PTR_ dwFlags);
+#endif
 }
 #endif // !defined( BOOST_USE_WINDOWS_H )
 


### PR DESCRIPTION
See [#11896](https://svn.boost.org/trac/boost/ticket/11896).