### PR TITLE
Remove duplicate boostdoc target

### DIFF
--- a/doc/Jamfile.v2
+++ b/doc/Jamfile.v2
@@ -19,9 +19,6 @@ boostbook standalone
     <format>pdf:<xsl:param>boost.url.prefix=http://www.boost.org/doc/libs/release/libs/winapi/doc/html
   ;
 
-alias boostdoc : standalone
-    : : : <implicit-dependency>standalone ;
-
 ###############################################################################
 alias boostdoc ;
 explicit boostdoc ;


### PR DESCRIPTION
It was confusing the documentation build.