### PR TITLE
add appveyor and travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,109 @@
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
+
+#
+# Generic Travis CI build script
+# For instructions on setting up your own fork and running CI builds before submitting
+# your changes into the official repository, see:
+# https://svn.boost.org/trac10/wiki/TravisCoverals
+#
+# Workflow:
+# Follow the instructions above.
+# Make sure your develop branch is synchronized with upstream.
+# Submit a pull request into your fork's develop.
+# Watch Travis CI build your change under a variety of compilers and language levels.
+#
+# Instructions for customizing this script for your library:
+# 
+# 1. Choose which compiler and language level combinations you want to run and
+#    uncomment them.
+# 2. Update the global B2 environment settings to your liking.
+# 3. If your project builds a library (is not header-only) you can get coveralls
+#    code coverage analysis by uncommenting the coverage job and copying the
+#    compute/.coveralls.yml file into your repository.
+#
+# That's it - the script will do everything else for you.
+
+language: cpp
+
+sudo: false
+dist: trusty
+
+os:
+  - linux
+
+branches:
+  only:
+    - develop
+    - master
+
+env:
+  global:
+    # see: http://www.boost.org/build/doc/html/bbv2/overview/invocation.html#bbv2.overview.invocation.properties
+    # to use the default for a given environment, comment it out; recommend you build debug and release however..
+    # - B2_ADDRESS_MODEL=address-model=64,32
+    # - B2_LINK=link=shared,static
+    # - B2_THREADING=threading=multi,single
+    - B2_VARIANT=variant=release,debug
+
+  matrix:
+    # This disables all built-in matrix build generation.
+    # We'll be specific about compilers and options.
+    - BOGUS_JOB=true
+
+matrix:
+  exclude:
+    - env: BOGUS_JOB=true
+
+  include:
+    - os: linux
+      env: COMMENT="c++03 gcc-4.8" TOOLSET=gcc COMPILER=g++ CXXSTD=c++03
+
+install:
+  - export SELF=`basename $TRAVIS_BUILD_DIR`
+  - cd ..
+  - git clone -b $TRAVIS_BRANCH --depth 1 https://github.com/boostorg/boost.git boost-root
+  - cd boost-root
+  - git submodule update --init tools/boostdep
+  - git submodule update --init tools/build
+  - git submodule update --init tools/inspect
+  - cp -r $TRAVIS_BUILD_DIR/* libs/$SELF
+  - export BOOST_ROOT="`pwd`"
+  - export PATH="`pwd`":$PATH 
+  - python tools/boostdep/depinst/depinst.py $SELF
+  - ./bootstrap.sh
+  - ./b2 headers
+
+script:
+  - export COMPILER_VERSION=`$COMPILER --version`
+  - |-
+    echo "using $TOOLSET : : $COMPILER : <cxxflags>-std=$CXXSTD ;" > ~/user-config.jam
+  - |-
+    echo "[**] COMPILER: $COMPILER_VERSION [**]"
+  - |-
+    echo "./b2 libs/$SELF/test toolset=$TOOLSET $B2_ADDRESS_MODEL $B2_LINK $B2_THREADING $B2_VARIANT -j3"
+  - ./b2 libs/$SELF/test toolset=$TOOLSET $B2_ADDRESS_MODEL $B2_LINK $B2_THREADING $B2_VARIANT -j3
+
+after_success:
+  # If this is not a profiling build skip the rest...
+  - if [[ "$COVERALL" -ne "1" ]]; then exit 0; fi
+
+  # Copying Coveralls data to a separate folder
+  - wget https://github.com/linux-test-project/lcov/archive/v1.13.zip
+  - unzip v1.13.zip
+  - LCOV="`pwd`/lcov-1.13/bin/lcov --gcov-tool gcov-6"
+
+  # Preparing Coveralls data
+  - mkdir -p $TRAVIS_BUILD_DIR/coverals
+  - $LCOV --directory bin.v2/libs/$SELF --base-directory libs/$SELF --capture --output-file $TRAVIS_BUILD_DIR/coverals/coverage.info --no-external
+  - $LCOV --remove $TRAVIS_BUILD_DIR/coverals/coverage.info "*/$SELF/test/*" --output-file $TRAVIS_BUILD_DIR/coverals/coverage-filtered.info
+
+  # Sending data to Coveralls
+  - cd $TRAVIS_BUILD_DIR
+  - gem install coveralls-lcov
+  - coveralls-lcov coverals/coverage-filtered.info
+
+notifications:
+  email:
+    false
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,117 @@
+# Copyright 2016, 2017 Peter Dimov
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
+
+# When copying this to a new library, be sure to update the name of the library
+# in two places (once each at the top of install: and test_script:)
+
+version: 1.0.{build}-{branch}
+
+shallow_clone: true
+
+branches:
+  only:
+    - develop
+    - master
+
+matrix:
+  allow_failures:
+    - MAYFAIL: true
+
+environment:
+  global:
+    # see: http://www.boost.org/build/doc/html/bbv2/overview/invocation.html#bbv2.overview.invocation.properties
+    # to use the default for a given environment, comment it out; recommend you build debug and release however..
+    # on Windows it is important to exercise all the possibilities, especially shared vs static
+    # B2_ADDRESS_MODEL: address-model=64,32
+    # B2_LINK: link=shared,static
+    B2_THREADING: threading=multi,single
+    B2_VARIANT: variant=release,debug
+
+  matrix:
+  # test older compilers
+    - TOOLSET: msvc-9.0
+      COMMENT: Visual Studio 2008
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+    - TOOLSET: msvc-10.0
+      COMMENT: Visual Studio 2010
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+    - TOOLSET: msvc-11.0
+      COMMENT: Visual Studio 2012
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+    - TOOLSET: msvc-12.0
+      COMMENT: Visual Studio 2013
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+    - ADDPATH: C:\cygwin\bin;
+      TOOLSET: gcc
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+    - ADDPATH: C:\mingw\bin;
+      TOOLSET: gcc
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+    - ADDPATH: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin;
+      TOOLSET: gcc
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+    - TOOLSET: msvc-14.0
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+  # test platform targets
+    - COMMENT: _WIN32_WINNT=0x0400 (NT4)
+      TOOLSET: msvc-14.1
+      DEFINES: define="_WIN32_WINNT=0x0400"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - COMMENT: _WIN32_WINNT=0x0500 (2K)
+      TOOLSET: msvc-14.1
+      DEFINES: define="_WIN32_WINNT=0x0500"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - COMMENT: _WIN32_WINNT=0x0501 (XP)
+      TOOLSET: msvc-14.1
+      DEFINES: define="_WIN32_WINNT=0x0501"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - COMMENT: _WIN32_WINNT=0x0502 (WS03)
+      TOOLSET: msvc-14.1
+      DEFINES: define="_WIN32_WINNT=0x0502"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - COMMENT: _WIN32_WINNT=0x0600 (VISTA/WS08)
+      TOOLSET: msvc-14.1
+      DEFINES: define="_WIN32_WINNT=0x0600"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - COMMENT: _WIN32_WINNT=0x0601 (WIN7)
+      TOOLSET: msvc-14.1
+      DEFINES: define="_WIN32_WINNT=0x0601"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - COMMENT: _WIN32_WINNT=0x0602 (WIN8)
+      TOOLSET: msvc-14.1
+      DEFINES: define="_WIN32_WINNT=0x0602"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - COMMENT: _WIN32_WINNT=0x0603 (WINBLUE)
+      TOOLSET: msvc-14.1
+      DEFINES: define="_WIN32_WINNT=0x0603"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - COMMENT: _WIN32_WINNT=0x0A00 (WIN10) DESKTOP (least restrictive)
+      TOOLSET: msvc-14.1
+      DEFINES: define="_WIN32_WINNT=0x0A00" define="WINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - COMMENT: _WIN32_WINNT=0x0A00 (WIN10) STORE (most restrictive)
+      TOOLSET: msvc-14.1
+      DEFINES: define="_WIN32_WINNT=0x0A00" define="WINAPI_FAMILY=WINAPI_FAMILY_PC_APP"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      MAYFAIL: true
+
+install:
+  - set SELF=winapi
+  - cd ..
+  - git clone -b %APPVEYOR_REPO_BRANCH% --depth 1 https://github.com/boostorg/boost.git boost-root
+  - cd boost-root
+  - git submodule update --init tools/boostdep
+  - git submodule update --init tools/build
+  - git submodule update --init tools/inspect
+  - xcopy /s /e /q %APPVEYOR_BUILD_FOLDER% libs\%SELF%
+  - python tools/boostdep/depinst/depinst.py %SELF%
+  - cmd /c bootstrap
+  - b2 headers
+
+build: off
+
+test_script:
+  - set SELF=winapi
+  - PATH=%ADDPATH%%PATH%
+  - b2 libs/%SELF%/test toolset=%TOOLSET% %CXXFLAGS% %DEFINES% %B2_ADDRESS_MODEL% %B2_LINK% %B2_THREADING% %B2_VARIANT% -j3


### PR DESCRIPTION
This pull request adds extensive CI testing on Appveyor and a minimal travis build to make sure linux didn't break.  On Appveyor many combinations of MSVC, Cygwin, MinGW, and MinGW-w64 environments are checked as well as all of the ``_WIN32_WINNT`` compile-time branches, and ``BOOST_USE_WINDOWS_H``.  The intention is to catch problems before they enter the codebase.  The CI build itself takes about 45 minutes when running one build job at a time.

To see the build results with these changes: jeking3#1

Note the PR build picked up four errors in develop that need to be addressed to get to a clean build.  This proves that the winapi headers in develop are not fully compatible with all target Windows platforms and validates the effort to add CI to the project.  These will be addressed with separate pull requests.

This fixes #46.