### PR TITLE
Fix issues found by new CI jobs: misalignments between Windows API and winapi

### DIFF
--- a/include/boost/detail/winapi/config.hpp
+++ b/include/boost/detail/winapi/config.hpp
@@ -23,7 +23,7 @@
 #endif
 #endif
 
-// These constants reflect _WIN32_WINNT_* macros from sdkddkver.h
+// These constants reflect _WIN32_WINNT_* macros from sdkddkver.h and will not change over time
 // See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa383745%28v=vs.85%29.aspx#setting_winver_or__win32_winnt
 #define BOOST_WINAPI_VERSION_NT4 0x0400
 #define BOOST_WINAPI_VERSION_WIN2K 0x0500
@@ -39,6 +39,23 @@
 #define BOOST_WINAPI_VERSION_WINTHRESHOLD 0x0A00
 #define BOOST_WINAPI_VERSION_WIN10 0x0A00
 
+#if defined(BOOST_USE_WINDOWS_H) && !defined(BOOST_WINAPI_IS_MINGW)
+// Defines VER_PRODUCTBUILD in case one needs a compile time
+// branch based on the Platform SDK / Windows Kit, available
+// back to at least kit 7.0 that shipped with Visual Studio 2010.
+#include <ntverp.h>
+#define BOOST_WINAPI_WINDOWS_SDK            VER_PRODUCTBUILD
+#else
+#define BOOST_WINAPI_WINDOWS_SDK            0
+#endif
+
+// These constants reflect the kit being used by VER_PRODUCTBUILD
+#define BOOST_WINAPI_WINDOWS_SDK_MINGW_W64  3790    /* https://github.com/Alexpux/mingw-w64/blame/master/mingw-w64-headers/include/ntverp.h */
+#define BOOST_WINAPI_WINDOWS_SDK_7          7600    /* covers 7.0, 7.1A */
+#define BOOST_WINAPI_WINDOWS_SDK_8          9200
+#define BOOST_WINAPI_WINDOWS_SDK_8_1        9600
+#define BOOST_WINAPI_WINDOWS_SDK_10         10011   /* covers all 10.0.<buildnum> */
+
 #if !defined(BOOST_USE_WINAPI_VERSION)
 #if defined(_WIN32_WINNT)
 #define BOOST_USE_WINAPI_VERSION _WIN32_WINNT
@@ -52,6 +69,32 @@
 #define BOOST_USE_WINAPI_VERSION BOOST_WINAPI_VERSION_WIN6
 #endif
 #endif
+#endif
+
+
+#if defined(BOOST_WINAPI_IS_MINGW_W64) || (BOOST_WINAPI_WINDOWS_SDK >= BOOST_WINAPI_WINDOWS_SDK_8)
+//
+// Windows family partitions - part of support for Windows Store, Windows Phone,
+// Windows Server, Windows Desktop differentiation in the API set.  They are only
+// meaningful if the Windows SDK has support for the concept.  The headers provided
+// are simple and do not pull in much, and they are quite different on certain SDKs.
+//
+// This is necessary to get UWP support.
+//
+
+#include <winapifamily.h>
+
+#if !defined(BOOST_USE_WINAPI_FAMILY)
+#if defined(WINAPI_FAMILY)
+#define BOOST_USE_WINAPI_FAMILY WINAPI_FAMILY
+#else
+// If none is specified, default to a desktop application which is the most
+// backwards compatible to previos ways of doing things.
+#define BOOST_USE_WINAPI_FMAILY WINAPI_FAMILY_DESKTOP_APP
+#endif
+#endif
+// Note that BOOST_USE_WINAPI_FAMILY may not have a definition, 
+// for example with SDK 7, and we account for this below.
 #endif
 
 #define BOOST_DETAIL_WINAPI_MAKE_NTDDI_VERSION2(x) x##0000
@@ -79,6 +122,9 @@
 #define NTDDI_VERSION 0x06010100
 #else
 #define NTDDI_VERSION BOOST_DETAIL_WINAPI_MAKE_NTDDI_VERSION(BOOST_USE_WINAPI_VERSION)
+#endif
+#if !defined(WINAPI_FAMILY) && defined(BOOST_USE_WINAPI_FAMILY)
+#define WINAPI_FAMILY BOOST_USE_WINAPI_FAMILY
 #endif
 #endif
 #endif

--- a/include/boost/detail/winapi/jobs.hpp
+++ b/include/boost/detail/winapi/jobs.hpp
@@ -11,7 +11,9 @@
 #include <boost/detail/winapi/basic_types.hpp>
 #include <boost/detail/winapi/access_rights.hpp>
 
-#if !defined( BOOST_USE_WINDOWS_H )
+#if BOOST_USE_WINAPI_VERSION >= BOOST_WINAPI_VERSION_WIN2K
+
+#if !defined(BOOST_USE_WINDOWS_H)
 extern "C" {
 #if !defined( BOOST_NO_ANSI_APIS )
 BOOST_SYMBOL_IMPORT boost::detail::winapi::HANDLE_ WINAPI CreateJobObjectA(
@@ -79,9 +81,7 @@ const DWORD_ JOB_OBJECT_ALL_ACCESS_ = (STANDARD_RIGHTS_REQUIRED_ | SYNCHRONIZE_ 
 #if !defined( BOOST_NO_ANSI_APIS )
 using ::OpenJobObjectA;
 #endif
-
 using ::OpenJobObjectW;
-
 using ::AssignProcessToJobObject;
 #if BOOST_USE_WINAPI_VERSION >= BOOST_WINAPI_VERSION_WINXP
 using ::IsProcessInJob;
@@ -123,5 +123,7 @@ BOOST_FORCEINLINE HANDLE_ open_job_object(DWORD_ dwDesiredAccess, BOOL_ bInherit
 } // namespace winapi
 } // namespace detail
 } // namespace boost
+
+#endif // BOOST_USE_WINAPI_VERSION >= BOOST_WINAPI_VERSION_WIN2K
 
 #endif // BOOST_DETAIL_WINAPI_JOBS_HPP_


### PR DESCRIPTION
Resolves incompatibilities with _WIN32_WINNT=0x0400 and 0x0A00 with the desktop family.  0x0501 was resolved with separate commits.

Results of Appveyor CI build:  https://ci.appveyor.com/project/jeking3/winapi/build/1.0.22-develop
Results of Travis CI build: https://travis-ci.org/jeking3/winapi/builds/276282135

This fixes #50
This fixes #52