### PR TITLE
[CMake] Add minimal cmake file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright 2018 Mike Dev
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+
+cmake_minimum_required(VERSION 3.5)
+project(BoostWinapi LANGUAGES CXX)
+
+add_library(boost_winapi INTERFACE)
+add_library(Boost::winapi ALIAS boost_winapi)
+
+target_include_directories(boost_winapi INTERFACE include)
+
+target_link_libraries(boost_winapi
+    INTERFACE
+        Boost::config
+        Boost::predef
+)


### PR DESCRIPTION
Generates cmake target that other libraries can use to express their dependency on this library and retrieve any configuration information such as the include directory, binary to link to (if any), transitive dependencies, necessary compiler options or the required c++ standards level.