### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,4 +1,4 @@
-# Copyright René Ferdinand Rivera Morell 2023
+# Copyright René Ferdinand Rivera Morell 2023-2024
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/winapi
     : common-requirements

--- a/build.jam
+++ b/build.jam
@@ -5,17 +5,20 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/config//boost_config
+    /boost/predef//boost_predef ;
+
 project /boost/winapi
     : common-requirements
-        <library>/boost/config//boost_config
-        <library>/boost/predef//boost_predef
         <include>include
     ;
 
 explicit
-    [ alias boost_winapi ]
+    [ alias boost_winapi : : : : <library>$(boost_dependencies) ]
     [ alias all : boost_winapi test ]
     ;
 
 call-if : boost-library winapi
     ;
+

--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,21 @@
+# Copyright René Ferdinand Rivera Morell 2023
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/winapi
+    : common-requirements
+        <source>/boost/config//boost_config
+        <source>/boost/predef//boost_predef
+        <include>include
+    ;
+
+explicit
+    [ alias boost_winapi ]
+    [ alias all : boost_winapi test ]
+    ;
+
+call-if : boost-library winapi
+    ;

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/winapi

--- a/build.jam
+++ b/build.jam
@@ -7,8 +7,8 @@ import project ;
 
 project /boost/winapi
     : common-requirements
-        <source>/boost/config//boost_config
-        <source>/boost/predef//boost_predef
+        <library>/boost/config//boost_config
+        <library>/boost/predef//boost_predef
         <include>include
     ;
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -24,6 +24,11 @@ project.pop-current ;
 project
     : requirements
 
+        <source>/boost/config//boost_config
+        <source>/boost/core//boost_core
+        <source>/boost/preprocessor//boost_preprocessor
+        <source>/boost/type_traits//boost_type_traits
+
         # Disable warnings about using 'insecure' standard C functions
         <toolset>msvc:<define>_SCL_SECURE_NO_WARNINGS
         <toolset>msvc:<define>_SCL_SECURE_NO_DEPRECATE
@@ -73,8 +78,7 @@ rule test_all
 {
     local all_rules ;
     local file ;
-    local headers_path = [ path.make $(BOOST_ROOT)/libs/winapi/include/boost/winapi ] ;
-    for file in [ path.glob-tree $(headers_path) : *.hpp : detail ]
+    for file in [ path.glob-tree ../include/boost/winapi : *.hpp : detail ]
     {
         local rel_file = [ path.relative-to [ path.parent $(headers_path) ] $(file) ] ;
         # Note: The test name starts with '~' in order to group these tests in the test report table, preferably at the end.
@@ -91,7 +95,7 @@ rule test_all
         all_rules += [ compile compile/windows_h_post.cpp : <conditional>@filter-target-os <define>"BOOST_WINAPI_TEST_HEADER=$(rel_file)" <dependency>$(file) : $(post_winh_test_name) ] ;
     }
 
-    headers_path = [ path.make $(BOOST_ROOT)/libs/winapi/include/boost/detail ] ;
+    headers_path = [ path.make ../include/boost/detail ] ;
     for file in [ path.glob $(headers_path) : *.hpp : detail ]
     {
         local rel_file = [ path.relative-to $(headers_path) $(file) ] ;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -15,10 +15,10 @@ lib advapi32 ;
 lib bcrypt ;
 lib user32 ;
 
-local here = [ modules.binding $(__name__) ] ;
+path-constant here : . ;
 
 project.push-current [ project.current ] ;
-project.load [ path.join [ path.make $(here:D) ] config/has-bcrypt ] ;
+project.load [ path.join [ path.make $(here) ] config/has-bcrypt ] ;
 project.pop-current ;
 
 project
@@ -78,7 +78,8 @@ rule test_all
 {
     local all_rules ;
     local file ;
-    for file in [ path.glob-tree ../include/boost/winapi : *.hpp : detail ]
+    local headers_path = ../include/boost/winapi ;
+    for file in [ path.glob-tree $(headers_path) : *.hpp : detail ]
     {
         local rel_file = [ path.relative-to [ path.parent $(headers_path) ] $(file) ] ;
         # Note: The test name starts with '~' in order to group these tests in the test report table, preferably at the end.
@@ -95,7 +96,7 @@ rule test_all
         all_rules += [ compile compile/windows_h_post.cpp : <conditional>@filter-target-os <define>"BOOST_WINAPI_TEST_HEADER=$(rel_file)" <dependency>$(file) : $(post_winh_test_name) ] ;
     }
 
-    headers_path = [ path.make ../include/boost/detail ] ;
+    headers_path = ../include/boost/detail ;
     for file in [ path.glob $(headers_path) : *.hpp : detail ]
     {
         local rel_file = [ path.relative-to $(headers_path) $(file) ] ;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -24,10 +24,10 @@ project.pop-current ;
 project
     : requirements
 
-        <source>/boost/config//boost_config
-        <source>/boost/core//boost_core
-        <source>/boost/preprocessor//boost_preprocessor
-        <source>/boost/type_traits//boost_type_traits
+        <library>/boost/config//boost_config
+        <library>/boost/core//boost_core
+        <library>/boost/preprocessor//boost_preprocessor
+        <library>/boost/type_traits//boost_type_traits
 
         # Disable warnings about using 'insecure' standard C functions
         <toolset>msvc:<define>_SCL_SECURE_NO_WARNINGS


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.