### PR TITLE
Allow direct cast of `get_proc_address` result

### DIFF
--- a/include/boost/winapi/get_proc_address.hpp
+++ b/include/boost/winapi/get_proc_address.hpp
@@ -63,18 +63,23 @@ using ::GetProcAddressA;
 using ::GetProcAddressW;
 #endif
 
-template<typename Signature = FARPROC_>
+BOOST_FORCEINLINE FARPROC_ get_proc_address(HMODULE_ hModule, LPCSTR_ lpProcName)
+{
+#if !defined(UNDER_CE)
+    return ::GetProcAddress(hModule, lpProcName);
+#else
+    return ::GetProcAddressA(hModule, lpProcName);
+#endif
+}
+
+template<typename Signature>
 BOOST_FORCEINLINE Signature get_proc_address(HMODULE_ hModule, LPCSTR_ lpProcName)
 {
 #if defined(BOOST_GCC) && BOOST_GCC >= 80000
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-function-type"
 #endif
-#if !defined(UNDER_CE)
-    return (Signature) ::GetProcAddress(hModule, lpProcName);
-#else
-    return (Signature) ::GetProcAddressA(hModule, lpProcName);
-#endif
+    return reinterpret_cast<Signature>(get_proc_address(hModule, lpProcName));
 #if defined(BOOST_GCC) && BOOST_GCC >= 80000
 #pragma GCC diagnostic pop
 #endif

--- a/include/boost/winapi/get_proc_address.hpp
+++ b/include/boost/winapi/get_proc_address.hpp
@@ -63,12 +63,20 @@ using ::GetProcAddressA;
 using ::GetProcAddressW;
 #endif
 
-BOOST_FORCEINLINE FARPROC_ get_proc_address(HMODULE_ hModule, LPCSTR_ lpProcName)
+template<typename Signature = FARPROC_>
+BOOST_FORCEINLINE Signature get_proc_address(HMODULE_ hModule, LPCSTR_ lpProcName)
 {
+#if defined(BOOST_GCC) && BOOST_GCC >= 80000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+#endif
 #if !defined(UNDER_CE)
-    return ::GetProcAddress(hModule, lpProcName);
+    return (Signature) ::GetProcAddress(hModule, lpProcName);
 #else
-    return ::GetProcAddressA(hModule, lpProcName);
+    return (Signature) ::GetProcAddressA(hModule, lpProcName);
+#endif
+#if defined(BOOST_GCC) && BOOST_GCC >= 80000
+#pragma GCC diagnostic pop
 #endif
 }
 


### PR DESCRIPTION
> GetProcAddress returns a pointer to some function. It can return pointers to different functions, so it has to return something that is suitable to store any pointer to function. Microsoft chose FARPROC, which is int (WINAPI *)() on 32-bit Windows. The user is supposed to know the signature of the function he requests and perform a cast (which is a nop on this platform). The result is a pointer to function with the required signature, which is bitwise equal to what GetProcAddress returned.
However, gcc >= 8 warns about that.

(See https://github.com/boostorg/thread/pull/405)


Add a template parameter to do the cast inside the function and suppress the warning there.

This allows to do the following replacement at the usage site without breaking backwards compatibility:

```diff
-        GetFileInformationByHandleEx_t* get_file_information_by_handle_ex = (GetFileInformationByHandleEx_t*)get_proc_address(h, "GetFileInformationByHandleEx");
+        GetFileInformationByHandleEx_t* get_file_information_by_handle_ex = get_proc_address<GetFileInformationByHandleEx_t*>(h, "GetFileInformationByHandleEx");
```

